### PR TITLE
Patch 1

### DIFF
--- a/terraform_deployment/README.md
+++ b/terraform_deployment/README.md
@@ -147,14 +147,14 @@ Open the **`terraform.tfvars`** file in your preferred text editor. Update the v
 #### 5. Create a Terraform plan
 Run the following command to create an execution plan, which lets you preview the changes that Terraform plans to make to your infrastructure:
 ```shell
-$ terraform plan
+terraform plan
 ```
 Ensure that the proposed changes match what you expected before you apply the changes!
 
 #### 6. Apply the Terraform plan
 Run the following command to execute the Terrafom code and apply the changes proposed in the `plan` step:
 ```shell
-$ terraform apply
+terraform apply
 ```
 
 ## Author Information


### PR DESCRIPTION
Fixed a few typos, and the other main change is that all of the copy text from the commands included the "$" command prompt so it gives errors if someone is using that copy/paste functionality.
I couldn't figure out how to keep $ on the same line and use the copy/paste functionality, so I thought it best just to remove them, better to have functional cut and paste at the expense of it not looking quite as nice.