### PR TITLE
Cosmetic changes to convenience scripts

### DIFF
--- a/fsx-ontap-aws-cli-scripts/README.md
+++ b/fsx-ontap-aws-cli-scripts/README.md
@@ -8,6 +8,7 @@ Windows Subsystem for Linux (WSL) based Linux distribution installed.
 Before running the UNIX based scripts, make sure the following package is installed:
 
 * jq  - lightweight and flexible command-line JSON processor
+* aws-cli - Command Line Interface for AWS
 
 ## Summary of the convenience scripts
 

--- a/fsx-ontap-aws-cli-scripts/create_fsxn_filesystem
+++ b/fsx-ontap-aws-cli-scripts/create_fsxn_filesystem
@@ -110,7 +110,10 @@ while [ ! -z "$1" ]; do
       endpointips='"EndpointIpAddressRange": "'$2'",'
       shift
       ;;
-    *) echo "Error, unknow options $1."
+    -h|-help|--help)
+      usage
+      ;;
+    *) echo "Error, unknown option $1." 1>&2
       usage
       ;;
   esac

--- a/fsx-ontap-aws-cli-scripts/create_fsxn_svm
+++ b/fsx-ontap-aws-cli-scripts/create_fsxn_svm
@@ -45,7 +45,6 @@ else
 fi
 #
 # Set some defaults.
-size=20
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.

--- a/fsx-ontap-aws-cli-scripts/create_fsxn_svm
+++ b/fsx-ontap-aws-cli-scripts/create_fsxn_svm
@@ -49,7 +49,7 @@ size=20
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "n:r:f:i:" option; do
+while getopts "hn:r:f:i:" option; do
   case $option in
     n) svmName=$OPTARG
       ;;
@@ -59,8 +59,7 @@ while getopts "n:r:f:i:" option; do
       ;;
     i) fsid=$OPTARG
       ;;
-    *) echo "Unknown option '$option'." 1>&2
-      usage
+    *) usage
       ;;
   esac
 done

--- a/fsx-ontap-aws-cli-scripts/create_fsxn_volume
+++ b/fsx-ontap-aws-cli-scripts/create_fsxn_volume
@@ -42,7 +42,7 @@ size=20
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "i:n:r:s:" option; do
+while getopts "hi:n:r:s:" option; do
   case $option in
     i) svmId=$OPTARG
       ;;

--- a/fsx-ontap-aws-cli-scripts/delete_fsxn_filesystem
+++ b/fsx-ontap-aws-cli-scripts/delete_fsxn_filesystem
@@ -21,11 +21,12 @@
 ################################################################################
 usage () {
 cat 1>&2 <<EOF
-Usage: $(basename $0) -f fileSystemName [-r region] [-i fileSystemID]
+Usage: $(basename $0) -f fileSystemName [-r region] [-i fileSystemID] [-b]
 Where:
   fileSystemName: Is the name of the file system you want to delete. This option is mutually exclusive to the -i option.
-  fileSystemID: Is the file system id of the file system you want to delete. This option is mutually exclusive to the -n option.
+  fileSystemID: Is the file system id of the file system you want to delete. This option is mutually exclusive to the -f option.
   region: Is the AWS region where the FSxN filesystem resides.
+  -b: enable final backup. Otherwise, it is skipped.
 EOF
   exit 1
 }
@@ -59,7 +60,8 @@ delete_volume () {
   trap 'rm -f $tmpout' RETURN
 
   local volumeId=$1
-  aws fsx delete-volume --volume-id $volumeId --region=$region --output=json --ontap-configuration '{"SkipFinalBackup": true}' > $tmpout 2>&1
+  local skipBackup=$2
+  aws fsx delete-volume --volume-id $volumeId --region=$region --output=json --ontap-configuration '{"SkipFinalBackup": '$skipBackup'}' > $tmpout 2>&1
   if [ $? != "0" ]; then
     printf "\nError, failed to delete a volume with volumeId: '$volumeId'.\n"  1>&2
     cat $tmpout 1>&2
@@ -163,9 +165,10 @@ fi
 #
 # Get the default region.
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
+skipBackup=true
 #
 # Process command line arguments.
-while getopts "hr:f:i:" option; do
+while getopts "hbr:f:i:" option; do
   case $option in
     f) fileSystemName=$OPTARG
       ;;
@@ -173,7 +176,9 @@ while getopts "hr:f:i:" option; do
       ;;
     i) fsid=$OPTARG
       ;;
-    *) usage  # implied exit
+    b) skipBackup=false
+      ;;
+    *) usage
       ;;
   esac
 done
@@ -265,7 +270,7 @@ for svmId in ${svms[*]}; do
     maxNumRunning=1  # Only do one initially, if it completes successfully, then do the rest concurrently.
     printf "\nDeleting all the volumes associated with ${svmId}.\n"
     while [ $i -lt $numVolumes ]; do
-      delete_volume ${volumes[$i]} &
+      delete_volume ${volumes[$i]} $skipBackup &
       let i+=1
       let numRunning+=1
       printf "\rTotal number of volumes to delete: ${numVolumes}. Number of deletes currently running: ${numRunning}. Number waiting to be started: $((numVolumes-i)).     "
@@ -312,7 +317,7 @@ done # for svmId in ${svms[*]}; do
 # Now that all the volumes are deleted, delete the SVMs.
 # Since there can only be 24 SVMs, don't really have to worry about spawning
 # too many at a time.
-printf "\nDeleting SVMs.\n"
+[ ${#svms[*]} -gt 0 ] && printf "\nDeleting SVMs.\n"
 for svmId in ${svms[*]}; do
   delete_svm $svmId &
 done

--- a/fsx-ontap-aws-cli-scripts/delete_fsxn_filesystem
+++ b/fsx-ontap-aws-cli-scripts/delete_fsxn_filesystem
@@ -165,7 +165,7 @@ fi
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "r:f:i:" option; do
+while getopts "hr:f:i:" option; do
   case $option in
     f) fileSystemName=$OPTARG
       ;;
@@ -173,8 +173,7 @@ while getopts "r:f:i:" option; do
       ;;
     i) fsid=$OPTARG
       ;;
-    *) echo "Error, unknown option '$option'." 1>&2
-      usage  # implied exit
+    *) usage  # implied exit
       ;;
   esac
 done

--- a/fsx-ontap-aws-cli-scripts/delete_fsxn_svm
+++ b/fsx-ontap-aws-cli-scripts/delete_fsxn_svm
@@ -47,14 +47,13 @@ fi
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "i:r:" option; do
+while getopts "hi:r:" option; do
   case $option in
     i) svmID=$OPTARG
       ;;
     r) region=$OPTARG
       ;;
-    *) echo "Error, unknown option '$option'." 1>&2
-      usage
+    *) usage
       ;;
   esac
   shift

--- a/fsx-ontap-aws-cli-scripts/delete_fsxn_volume
+++ b/fsx-ontap-aws-cli-scripts/delete_fsxn_volume
@@ -20,10 +20,11 @@
 ################################################################################
 usage () {
 cat 1>&2 <<EOF
-Usage: $(basename $0) -i volumeID [-r region]
+Usage: $(basename $0) -i volumeID [-r region] [-b]
 where
   volumeID: is the ID of the volume to delete.
   region: is the AWS region where the FSxN filesystem resides.
+  -b: enable final backup. Otherwise it is skipped.
 EOF
   exit 1
 }
@@ -38,11 +39,14 @@ trap 'rm -f $tmpout' exit
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "hi:r:" option; do
+skipBackup=true
+while getopts "hbi:r:" option; do
   case $option in
     r) region="$OPTARG"
       ;;
     i) volumeId="$OPTARG"
+      ;;
+    b) skipBackup=false
       ;;
     *) usage
       ;;
@@ -55,7 +59,7 @@ if [ -z "$volumeId" ]; then
   usage
 fi
 
-aws fsx delete-volume --volume-id $volumeId --region=$region --output=json > $tmpout 2>&1
+aws fsx delete-volume --volume-id $volumeId --region=$region --output=json --ontap-configuration '{"SkipFinalBackup": '$skipBackup'}' > $tmpout 2>&1
 
 if [ $? != "0" ]; then
   echo "Failed to delete volume." 1>&2

--- a/fsx-ontap-aws-cli-scripts/delete_fsxn_volume
+++ b/fsx-ontap-aws-cli-scripts/delete_fsxn_volume
@@ -38,7 +38,7 @@ trap 'rm -f $tmpout' exit
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "i:r:" option; do
+while getopts "hi:r:" option; do
   case $option in
     r) region="$OPTARG"
       ;;

--- a/fsx-ontap-aws-cli-scripts/list_fsxn_filesystems
+++ b/fsx-ontap-aws-cli-scripts/list_fsxn_filesystems
@@ -75,7 +75,7 @@ showStatus=false
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "csanr:i:f:" option; do
+while getopts "hcsanr:i:f:" option; do
   case "$option" in
     r) region="$OPTARG"
       ;;
@@ -91,8 +91,7 @@ while getopts "csanr:i:f:" option; do
       ;;
     s) showStatus=true
       ;;
-    *) echo "Error, unknown option '$option'." 1>&2
-      usage
+    *) usage
       ;;
   esac
 done

--- a/fsx-ontap-aws-cli-scripts/list_fsxn_filesystems
+++ b/fsx-ontap-aws-cli-scripts/list_fsxn_filesystems
@@ -23,6 +23,8 @@
 #   o Management IP
 #   o VPC ID - optional
 #   o Subnet ID - optional
+#   o ARN - optional
+#   o Backup - The Backup retention period.
 #
 # In the case of the Management IP and Subnet ID, it will only show the first
 # one defined. Based on the potential output from the API call, there could
@@ -38,14 +40,17 @@
 ################################################################################
 usage () {
   cat 1>&2 <<EOF
-Usage $(basename $0) [-r region] [-a] [-n] [-c] [-s] [-i fileSystemId] [-f fileSystemName]
-  Where: -r region allows you to specify the region you want the list from.
+Usage $(basename $0) [-r region] [-a] [-n] [-c] [-s] [-b] [-i fileSystemId] [-f fileSystemName] [-x] [pattern]
+  Where: pattern - means to only show file systems whos name match the pattern.
+         -r region allows you to specify the region you want the list from.
          -a means all regions.
-         -n means include additional network information.
          -c means to display a hierarchical view of each filesystem including svms and volumes.
          -i allows you to limit the display to the file system with the id provided.
          -f allows you to limit the display to the file system with the name provided.
+         -b means to display the backup retenion period. Not compoatible with the -x or -c options.
          -s means to display the current status of a volume. Only relative with the -c option.
+         -n means to show the AWS ARN for the file system. Not compatible with -x or -c options.
+         -x means include additional information: vpc, subnet, Size, Deployement Type, Throughput, provisioned IOPS.
 EOF
   exit 1
 }
@@ -69,19 +74,23 @@ fi
 #
 # Set defaults.
 allRegions=false
-includeNetworking=false
+includeExtraInfo=false
 contents=false
 showStatus=false
+showARN=false
+showBackup=false
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
 #
 # Process command line arguments.
-while getopts "hcsanr:i:f:" option; do
+while getopts "bhcxsanr:i:f:" option; do
   case "$option" in
     r) region="$OPTARG"
       ;;
     a) allRegions=true
       ;;
-    n) includeNetworking=true
+    b) showBackup=true
+      ;;
+    x) includeExtraInfo=true
       ;;
     c) contents=true
       ;;
@@ -91,15 +100,54 @@ while getopts "hcsanr:i:f:" option; do
       ;;
     s) showStatus=true
       ;;
+    n) showARN=true
+      ;;
     *) usage
       ;;
   esac
 done
+shift $((OPTIND-1))
+#
+# Check for invalid options.
+if [ "$showBackup" == "true" -a \( "$contents" == "true" -o "$includeExtraInfo" == "true" \) ]; then
+  echo "Error, the -b option is not compatiable with the -c or -x options." 1>&2
+  echo ""
+  usage
+fi
 
-if [ "$allRegions" = "true" ]; then
-  regions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output=json | jq -r '.[]')
+if [ "$showARN" == "true" -a \( "$contents" == "true" -o "$includeExtraInfo" == "true" \) ]; then
+  echo "Error, the -n option is not compatiable with the -c or -x options." 1>&2
+  echo ""
+  usage
+fi
+
+if [ "$showStatus" == "true" -a "$contents" != "true" ]; then
+  echo "Error, the -s option is only compatiable with the -c option." 1>&2
+  echo ""
+  usage
+fi
+
+declare -a regions
+if [ "$allRegions" == "true" ]; then
+  #
+  # Generate a list of all the valid regions the user can search. That is the
+  # intersection of all the regions they have enabled, and the regions that
+  # support FSxN
+  allEndabledRegions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output=json | jq -r '.[]')
+  allFsxnRegions=$(curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[] | select(.attributes."aws:serviceName" == "Amazon FSx for NetApp ONTAP") .attributes."aws:region"')
+  for reg in $allEndabledRegions; do
+    for fsxnReg in $allFsxnRegions; do
+      if [ $reg == $fsxnReg ]; then
+        regions+=($reg)
+      fi
+    done
+  done
+  if [ -z "$regions" ]; then
+    echo "Error, failed to get the list of regions that support FSxN" 1>&2
+    exit 1
+  fi
 else
-  regions=$region
+  regions=($region)
 fi
 
 if [ ! -z "$fsid" -a ! -z "$fileSystemName" ]; then
@@ -107,73 +155,111 @@ if [ ! -z "$fsid" -a ! -z "$fileSystemName" ]; then
   exit 1
 fi
 #
+# Get the regions that support the FSxN for ONTAP service.
+#
+# Define the query string that is used to get only the fields needed to generate the output.
+# It also makes the 'jq' commands below easily, since it flattens the JSON structure.
+queryString="FileSystems[*].{
+  FileSystemId: FileSystemId,
+  Lifecycle:Lifecycle,
+  Name:Tags[?Key=='Name']|[0].Value,
+  ManagementIp: OntapConfiguration.Endpoints.Management.IpAddresses[0],
+  VpcId: VpcId,
+  SubnetId: SubnetIds[0],
+  ResourceARN: ResourceARN,
+  AutomaticBackupRetentionDays: OntapConfiguration.AutomaticBackupRetentionDays,
+  DeploymentType: OntapConfiguration.DeploymentType,
+  DiskIopsConfiguration: OntapConfiguration.DiskIopsConfiguration.Iops,
+  ThroughputCapacity: OntapConfiguration.ThroughputCapacity,
+  StorageCapacity: StorageCapacity
+}"
+#
 # Loop on all the requested regions.
-for region in $regions; do
-  #
-  # Check that the fsx service is supported in thie region
-  if [ ! -z "$(getent hosts fsx.$region.amazonaws.com)" ]; then
-    if [ ! -z "$fileSystemName" ]; then
-      fsid=$(aws fsx describe-file-systems --region=$region --output=json 2> /dev/null | jq -r '.FileSystems[] | if((.Tags[] | select(.Key == "Name") .Value) == "'"${fileSystemName}"'") then .FileSystemId else empty end' 2> /dev/null)
-      if [ ! -z "$fsid" ]; then
-        aws fsx describe-file-systems --file-system-ids $fsid --region=$region --output=json > $fileSystemsFile 2>&1
-      else
-        echo "Error, failed to get the file system ID based on a file system name of '$fileSystemName'." 1>&2
-        exit 1
-      fi
+for region in ${regions[*]}; do
+  if [ ! -z "$fileSystemName" ]; then
+    fsid=$(aws fsx describe-file-systems --region=$region --output=json 2> /dev/null | jq -r '.FileSystems[] | if((.Tags[] | select(.Key == "Name") .Value) == "'"${fileSystemName}"'") then .FileSystemId else empty end' 2> /dev/null)
+    if [ ! -z "$fsid" ]; then
+      aws fsx describe-file-systems --file-system-ids $fsid --region=$region --query "$queryString" --output=json > $fileSystemsFile 2>&1
     else
-      if [ -z "$fsid" ]; then
-        aws fsx describe-file-systems --region=$region --output=json > $fileSystemsFile 2>&1
-      else
-        aws fsx describe-file-systems --file-system-ids $fsid --region=$region --output=json > $fileSystemsFile 2>&1
-      fi
-    fi
-
-    if [ $? -ne 0 ]; then
-      echo "Error, failed to get the list of file systems." 1>&2
-      cat $fileSystemsFile 1>&2
+      echo "Error, failed to get the file system ID based on a file system name of '$fileSystemName'." 1>&2
       exit 1
     fi
-  
-    if [ $contents == "true" ]; then
-      aws fsx describe-storage-virtual-machines --region=$region --output=json > $svmsFile 2>&1
-      if [ $? -ne 0 ]; then
-        echo "Error, failed to get the list of SVMs." 1>&2
-        cat $svmsFile 1>&2
-        exit 1
-      fi
-  
-      aws fsx describe-volumes --region=$region --output=json > $volumesFile 2>&1
-      if [ $? -ne 0 ]; then
-        echo "Error, failed to get the list of volumes." 1>&2
-        cat $volumesFile 1>&2
-        exit 1
-      fi
-  
-      printf "$region\n"
-      jq -r '.FileSystems[] | .FileSystemId + " " + .Lifecycle + " " + (.Tags[] | select(.Key == "Name") .Value)' $fileSystemsFile | while read fs fsStatus fsName; do
-        [ "$showStatus" == "true" ] && printf "\t$fs($fsStatus) - '$fsName'\n"
-        [ "$showStatus" != "true" ] && printf "\t$fs - '$fsName'\n"
-        jq -r '.StorageVirtualMachines[] | if(.FileSystemId == "'$fs'") then .StorageVirtualMachineId + " " + .Lifecycle + " " + .Name else empty end' $svmsFile | while read svm svmStatus svmName; do
-          [ "$showStatus" == "true" ] && printf "\t\t$svm($svmStatus) - '$svmName'\n"
-          [ "$showStatus" != "true" ] && printf "\t\t$svm - '$svmName'\n"
-          jq -r '.Volumes[] | if(.FileSystemId == "'$fs'" and .OntapConfiguration.StorageVirtualMachineId == "'$svm'") then .VolumeId + " " + .Lifecycle + " " + .Name else empty end' $volumesFile | while read volume volStatus volumeName; do
-            [ "$showStatus" == "true" ] && printf "\t\t\t$volume($volStatus) - '$volumeName'\n"
-            [ "$showStatus" != "true" ] && printf "\t\t\t$volume - '$volumeName'\n"
-          done
+  else
+    if [ -z "$fsid" ]; then
+      aws fsx describe-file-systems --region=$region --query "$queryString" --output=json > $fileSystemsFile 2>&1
+    else
+      aws fsx describe-file-systems --file-system-ids $fsid --region=$region --query "$queryString" --output=json > $fileSystemsFile 2>&1
+    fi
+  fi
+
+  if [ $? -ne 0 ]; then
+    echo "Error, failed to get the list of file systems." 1>&2
+    cat $fileSystemsFile 1>&2
+    exit 1
+  fi
+
+  if [ $contents == "true" ]; then
+    aws fsx describe-storage-virtual-machines --region=$region --output=json > $svmsFile 2>&1
+    if [ $? -ne 0 ]; then
+      echo "Error, failed to get the list of SVMs." 1>&2
+      cat $svmsFile 1>&2
+      exit 1
+    fi
+
+    aws fsx describe-volumes --region=$region --output=json > $volumesFile 2>&1
+    if [ $? -ne 0 ]; then
+      echo "Error, failed to get the list of volumes." 1>&2
+      cat $volumesFile 1>&2
+      exit 1
+    fi
+
+    printf "$region\n"
+    jq -r '.[] | .FileSystemId + " " + .Lifecycle + " =" + .Name + "="' $fileSystemsFile | while read fs fsStatus fsName; do
+      x="${fsName#=}"
+      fsName="${x%=}"
+      [ "$showStatus" == "true" ] && printf "\t$fs($fsStatus) - '$fsName'\n"
+      [ "$showStatus" != "true" ] && printf "\t$fs - '$fsName'\n"
+      jq -r '.StorageVirtualMachines[] | if(.FileSystemId == "'$fs'") then .StorageVirtualMachineId + " " + .Lifecycle + " " + .Name else empty end' $svmsFile | while read svm svmStatus svmName; do
+        [ "$showStatus" == "true" ] && printf "\t\t$svm($svmStatus) - '$svmName'\n"
+        [ "$showStatus" != "true" ] && printf "\t\t$svm - '$svmName'\n"
+        jq -r '.Volumes[] | if(.FileSystemId == "'$fs'" and .OntapConfiguration.StorageVirtualMachineId == "'$svm'") then .VolumeId + " " + .Lifecycle + " " + .Name else empty end' $volumesFile | while read volume volStatus volumeName; do
+          [ "$showStatus" == "true" ] && printf "\t\t\t$volume($volStatus) - '$volumeName'\n"
+          [ "$showStatus" != "true" ] && printf "\t\t\t$volume - '$volumeName'\n"
         done
       done
-    else
-      jq -r '.FileSystems[] | .FileSystemId + "," + (.Tags[] | select(.Key == "Name") .Value) + "," + .Lifecycle + "," + .OntapConfiguration.Endpoints.Management.IpAddresses[0] + "," + .VpcId + "," + .SubnetIds[0]' $fileSystemsFile > $tmpout
-  
-      if [ "$includeNetworking" == "true" ]; then
-        awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %35s %10s %15s %21s %24s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "Name", "Status", "Managment IP", "VPC ID", "Subnet ID"; first=0}; printf formatStr, region, $1, $2, $3, $4, $5, $6}' < $tmpout
-      else
-        awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %35s %10s %15s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "Name", "Status", "Managment IP", "VPC ID", "Subnet ID"; first=0}; printf formatStr, region, $1, $2, $3, $4}' < $tmpout
-      fi
-    fi
+    done
   else
-    if [ $allRegions != "true" ]; then
-      printf "The fsx service is currently not supported in the $region region.\n"
+    #
+    # Convert JSON into a CSV format.
+    # 1 = fsid
+    # 2 = arn
+    # 3 = name
+    # 4 = lifecycle
+    # 5 = management ip
+    # 6 = vpc id
+    # 7 = subnet id
+    # 8 = backup retention
+    # 9 = deployment type
+    # 10 = iops
+    # 11 = throughput
+    # 12 = size
+    if [ ! -z "$1" ]; then
+      #set -x
+      jq -r '.[] | .FileSystemId + "," + .ResourceARN + "," + (if((.Name | tostring) | test("'$1'")) then .Name else empty end) + "," + .Lifecycle + "," + .ManagementIp + "," + .VpcId + "," + .SubnetId + "," + (if(.AutomaticBackupRetentionDays == null) then "Dissabled" else (.AutomaticBackupRetentionDays | tostring) end) + "," + .DeploymentType + "," + (.DiskIopsConfiguration | tostring) + "," + (.ThroughputCapacity | tostring) + "," + (.StorageCapacity | tostring)' $fileSystemsFile > $tmpout
+    else
+      jq -r '.[] | .FileSystemId + "," + .ResourceARN + "," + .Name + "," + .Lifecycle + "," + .ManagementIp + "," + .VpcId + "," + .SubnetId + "," + if(.AutomaticBackupRetentionDays == null) then "Dissabled" else (.AutomaticBackupRetentionDays | tostring) end + "," + .DeploymentType + "," + (.DiskIopsConfiguration | tostring) + "," + (.ThroughputCapacity | tostring) + "," + (.StorageCapacity | tostring)' $fileSystemsFile > $tmpout
+    fi
+
+    if [ "$includeExtraInfo" == "true" ]; then
+      awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %35s %10s %15s %22s %25s %6s %12s %11s %6s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "Name", "Status", "Management IP", "VPC ID", "Subnet ID", "Size", "Deployment", "Throughput", "Iops"; first=0}; printf formatStr, region, $1, "\"" $3 "\"", $4, $5, $6, $7, $(12), $9, $(11), $(10)}' < $tmpout
+    else
+      if [ "$showARN" == "true" ]; then
+        awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %70s %35s %10s %15s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "ARN", "Name", "Status", "Management IP"; first=0}; printf formatStr, region, $1, $2, "\"" $3 "\"", $4, $5}' < $tmpout
+      else
+        formatStr='%12s %23s %35s %10s %15s\n'
+        [ "$showBackup" == "true" ] && formatStr='%12s %23s %35s %10s %15s %17s\n'
+        awk -F, -v region=$region 'BEGIN {first=1; formatStr="'"${formatStr}"'"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "Name", "Status", "Management IP", "Backup Retention"; first=0}; printf formatStr, region, $1, "\"" $3 "\"", $4, $5, $8}' < $tmpout
+      fi
     fi
   fi
 done

--- a/fsx-ontap-aws-cli-scripts/list_fsxn_svms
+++ b/fsx-ontap-aws-cli-scripts/list_fsxn_svms
@@ -79,35 +79,43 @@ if [ ! -z "$fileSystemID" -a ! -z "$fileSystemName" ]; then
 fi
 
 if [ "$allRegions" = "true" ]; then
-  regions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output=json | jq -r '.[]')
+  #
+  # Generate a list of all the valid regions the user can search. That is the
+  # intersection of all the regions they have enabled, and the regions that
+  # support FSxN
+  allEndabledRegions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output=json | jq -r '.[]')
+  allFsxnRegions=$(curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[] | select(.attributes."aws:serviceName" == "Amazon FSx for NetApp ONTAP") .attributes."aws:region"')
+  for reg in $allEndabledRegions; do
+    for fsxnReg in $allFsxnRegions; do
+      if [ $reg == $fsxnReg ]; then
+        regions+=($reg)
+      fi
+    done
+  done
+  if [ -z "$regions" ]; then
+    echo "Error, failed to get the list of regions that support FSxN" 1>&2
+    exit 1
+  fi
 else
-  regions=$region
+  regions=($region)
 fi
 
-if [ ! -z "$fileSystenName" ]; then
+if [ ! -z "$fileSystemName" ]; then
   fileSystemID=$(aws fsx describe-file-systems --output=json 2> /dev/null | jq -r '.FileSystems[] | if((.Tags[] | select(.Key == "Name") .Value) == "'"${fileSystemName}"'") then .FileSystemId else empty end' 2> /dev/null)
 fi
 #
 # Loop on all the regions.
-for region in $regions; do
-  #
-  # Check that the fsx service is supported in thie region
-  if [ ! -z "$(getent hosts fsx.$region.amazonaws.com)" ]; then
-    if [ -z "$fileSystemID" ]; then
-      aws fsx describe-storage-virtual-machines --region=$region | jq -r '.StorageVirtualMachines[] | .FileSystemId + "," + .StorageVirtualMachineId + "," + .Name' | sort > $tmpout
-    else
-      aws fsx describe-storage-virtual-machines --region=$region | jq -r '.StorageVirtualMachines[] | if(.FileSystemId == "'$fileSystemID'") then .FileSystemId + "," + .StorageVirtualMachineId + "," + .Name else empty end' | sort > $tmpout
-    fi
-  
-    if [ $includeFsName == "true" ]; then
-      aws fsx describe-file-systems --region=$region | jq -r '.FileSystems[] | .FileSystemId + "," + (.Tags[] | select(.Key == "Name") .Value)' > $tmpout2
-      awk -F, -v region=$region 'BEGIN {first=1; maxNameLen=0; while(getline < "'$tmpout2'") {fss[$1]=$2; if(length($2) > maxNameLen) {maxNameLen=length($2)}}; maxNameLen +=2; formatStr="%12s %20s%-"maxNameLen"s %23s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "(Name)", "SVM ID", "SVM Name"; first=0}; name="("fss[$1]")"; printf formatStr, region, $1, name, $2, $3}' < $tmpout
-    else
-      awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %23s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "SVM ID", "SVM Name"; first=0}; printf formatStr, region, $1, $2, $3}' < $tmpout
-    fi
+for region in ${regions[*]}; do
+  if [ -z "$fileSystemID" ]; then
+    aws fsx describe-storage-virtual-machines --region=$region | jq -r '.StorageVirtualMachines[] | .FileSystemId + "," + .StorageVirtualMachineId + "," + .Name' | sort > $tmpout
   else
-    if [ $allRegions != "true" ]; then
-      printf "The fsx service is currently not supported in the $region region.\n"
-    fi
+    aws fsx describe-storage-virtual-machines --region=$region | jq -r '.StorageVirtualMachines[] | if(.FileSystemId == "'$fileSystemID'") then .FileSystemId + "," + .StorageVirtualMachineId + "," + .Name else empty end' | sort > $tmpout
+  fi
+  
+  if [ $includeFsName == "true" ]; then
+    aws fsx describe-file-systems --region=$region | jq -r '.FileSystems[] | .FileSystemId + "," + (.Tags[] | select(.Key == "Name") .Value)' > $tmpout2
+    awk -F, -v region=$region 'BEGIN {first=1; maxNameLen=0; while(getline < "'$tmpout2'") {fss[$1]=$2; if(length($2) > maxNameLen) {maxNameLen=length($2)}}; maxNameLen +=2; formatStr="%12s %20s%-"maxNameLen"s %23s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "(Name)", "SVM ID", "SVM Name"; first=0}; name="("fss[$1]")"; printf formatStr, region, $1, name, $2, $3}' < $tmpout
+  else
+    awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %23s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "SVM ID", "SVM Name"; first=0}; printf formatStr, region, $1, $2, $3}' < $tmpout
   fi
 done

--- a/fsx-ontap-aws-cli-scripts/list_fsxn_svms
+++ b/fsx-ontap-aws-cli-scripts/list_fsxn_svms
@@ -56,7 +56,7 @@ fi
 allRegions=false
 includeFsName=false
 region=$(aws configure list | egrep '^.*egion ' | awk '{print $2}')
-while getopts "anr:i:f:" option; do
+while getopts "hanr:i:f:" option; do
   case "$option" in
     r) region="$OPTARG"
       ;;
@@ -68,8 +68,7 @@ while getopts "anr:i:f:" option; do
       ;;
     f) fileSystemName="$OPTARG"
       ;;
-    *) echo "Error, unknown option '$option'." 1>&2
-      usage
+    *) usage
       ;;
   esac
 done

--- a/fsx-ontap-aws-cli-scripts/list_fsxn_volumes
+++ b/fsx-ontap-aws-cli-scripts/list_fsxn_volumes
@@ -64,7 +64,7 @@ excludeRoot=false
 filter=""
 fsid=""
 fileSystemName=""
-while getopts "r:af:i:nos:" option; do
+while getopts "hr:af:i:nos:" option; do
   case "$option" in
     r) region="$OPTARG"
       ;;
@@ -92,8 +92,7 @@ while getopts "r:af:i:nos:" option; do
       ;;
     s) svmID="$OPTARG"
       ;;
-    *) echo "Error, unknown option '$option'." 1>&2
-      usage
+    *) usage
       ;;
   esac
 done

--- a/fsx-ontap-aws-cli-scripts/list_fsxn_volumes
+++ b/fsx-ontap-aws-cli-scripts/list_fsxn_volumes
@@ -20,6 +20,7 @@
 #   o File System Name - optional
 #   o Volume ID
 #   o Volume Name
+#   o Volume Status
 #
 ################################################################################
 
@@ -71,19 +72,8 @@ while getopts "hr:af:i:nos:" option; do
     a) allRegions=true
       ;;
     f) fileSystemName="$OPTARG"
-      fsid=$(aws fsx describe-file-systems --output=json 2> /dev/null | jq -r ".FileSystems[] | if((.Tags[] | select(.Key == \"Name\") .Value) == \"${fileSystemName}\") then .FileSystemId else empty end" 2> /dev/null)
-      if [ -z "$fsid" ]; then
-        echo "Error, failed to find the file system with the file system name of '$OPTARG'." 1>&2
-        exit 1
-      fi
-      filter='--filters [{"Name":"file-system-id","Values":["'$fsid'"]}]'
       ;;
-    i) fileSystemName=$(aws fsx describe-file-systems --output=json 2> /dev/null | jq -r ".FileSystems[] | if(.FileSystemId == \"$OPTARG\") then (.Tags[] | select(.Key == \"Name\") .Value) else empty end" 2> /dev/null)
-      if [ -z "$fileSystemName" ]; then
-        echo "Error, failed to find the file system with the file system ID of '$OPTARG'." 1>&2
-        exit 1
-      fi
-      filter='--filters [{"Name":"file-system-id","Values":["'$OPTARG'"]}]'
+    i) fsid="$OPTARG"
       ;;
     n) includeFsName=true
       ;;
@@ -97,36 +87,75 @@ while getopts "hr:af:i:nos:" option; do
   esac
 done
 
+if [ ! -z "$fileSystenName" -a ! -z "$fsid" ]; then
+  echo "Error, you can't provide both -f and -n options." 1>&2
+  exit 1
+fi
+
+if [ ! -z "$fileSystemName" ]; then
+  fsid=$(aws fsx describe-file-systems --region $region --output=json 2> /dev/null | jq -r ".FileSystems[] | if((.Tags[] | select(.Key == \"Name\") .Value) == \"${fileSystemName}\") then .FileSystemId else empty end" 2> /dev/null)
+  if [ -z "$fsid" ]; then
+    echo "Error, failed to find the file system with the file system name of '$fileSystemName'." 1>&2
+    exit 1
+  fi
+  filter='--filters [{"Name":"file-system-id","Values":["'$fsid'"]}]'
+fi
+
+if [ ! -z "$fsid" -a -z "$fileSystemName" ]; then
+  fileSystemName=$(aws fsx describe-file-systems --region $region --output=json 2> /dev/null | jq -r ".FileSystems[] | if(.FileSystemId == \"$fsid\") then (.Tags[] | select(.Key == \"Name\") .Value) else empty end" 2> /dev/null)
+  if [ -z "$fileSystemName" ]; then
+    echo "Error, failed to find the file system with the file system ID of '$fsid'." 1>&2
+    exit 1
+  fi
+  filter='--filters [{"Name":"file-system-id","Values":["'$fsid'"]}]'
+fi
+
 if [ "$allRegions" = "true" ]; then
-  regions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output=json | jq -r '.[]')
+  #
+  # Generate a list of all the valid regions the user can search. That is the
+  # intersection of all the regions they have enabled, and the regions that
+  # support FSxN
+  allEndabledRegions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output=json | jq -r '.[]')
+  allFsxnRegions=$(curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[] | select(.attributes."aws:serviceName" == "Amazon FSx for NetApp ONTAP") .attributes."aws:region"')
+  for reg in $allEndabledRegions; do
+    for fsxnReg in $allFsxnRegions; do
+      if [ $reg == $fsxnReg ]; then
+        regions+=($reg)
+      fi
+    done
+  done
+  if [ -z "$regions" ]; then
+    echo "Error, failed to get the list of regions that support FSxN" 1>&2
+    exit 1
+  fi
 else
-  regions=$region
+  regions=($region)
 fi
 #
 # Loop on all the regions.
-for region in $regions; do
+for region in ${regions[*]}; do
   #
   # Check that the fsx service is supported in thie region
   if [ ! -z "$(getent hosts fsx.$region.amazonaws.com)" ]; then
     if [ -z "$svmID" ]; then
       if [ "$excludeRoot" != "true" ]; then
-        aws fsx describe-volumes $filter --region=$region --output=json | jq -r '.Volumes[] | .FileSystemId + "," + .Name + "," + .VolumeId' | sort > $tmpout
+        aws fsx describe-volumes $filter --region=$region --output=json | jq -r '.Volumes[] | .FileSystemId + "," + .Name + "," + .VolumeId + "," + .Lifecycle' | sort > $tmpout
       else
-        aws fsx describe-volumes $filter --region=$region --output=json | jq -r '.Volumes[] | if(.OntapConfiguration.StorageVirtualMachineRoot | not) then .FileSystemId + "," + .Name + "," + .VolumeId else empty end' | sort > $tmpout
+        aws fsx describe-volumes $filter --region=$region --output=json | jq -r '.Volumes[] | if(.OntapConfiguration.StorageVirtualMachineRoot | not) then .FileSystemId + "," + .Name + "," + .VolumeId + "," + .Lifecycle else empty end' | sort > $tmpout
       fi
     else
       if [ "$excludeRoot" != "true" ]; then
-        aws fsx describe-volumes $filter --region=$region --output=json | jq -r ".Volumes[] | if(.OntapConfiguration.StorageVirtualMachineId == \"$svmID\") then .FileSystemId + \",\" + .Name + \",\" + .VolumeId else empty end" | sort > $tmpout
+        aws fsx describe-volumes $filter --region=$region --output=json | jq -r '.Volumes[] | if(.OntapConfiguration.StorageVirtualMachineId == "'$svmID'") then .FileSystemId + "," + .Name + "," + .VolumeId + "," + .Lifecycle else empty end' | sort > $tmpout
       else
-        aws fsx describe-volumes $filter --region=$region --output=json | jq -r ".Volumes[] | if(.OntapConfiguration.StorageVirtualMachineId == \"$svmID\" and (.OntapConfiguration.StorageVirtualMachineRoot | not)) then .FileSystemId + \",\" + .Name + \",\" + .VolumeId else empty end" | sort > $tmpout
+        aws fsx describe-volumes $filter --region=$region --output=json | jq -r '.Volumes[] | if(.OntapConfiguration.StorageVirtualMachineId == "'$svmID'" and (.OntapConfiguration.StorageVirtualMachineRoot | not)) then .FileSystemId + "," + .Name + "," + .VolumeId + "," + .Lifecycle else empty end' | sort > $tmpout
       fi
     fi
   
     if [ $includeFsName == "true" ]; then
       aws fsx describe-file-systems --region=$region --output=json | jq -r '.FileSystems[] | .FileSystemId + "," + (.Tags[] | select(.Key == "Name") .Value)' | fgrep "$fileSystemName" > $tmpout2
-      awk -F, -v region=$region 'BEGIN {first=1; maxNameLen=0; while(getline < "'$tmpout2'") {fss[$1]=$2; if(length($2) > maxNameLen) {maxNameLen=length($2)}}; maxNameLen +=2; formatStr="%12s %20s%-"maxNameLen"s %23s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "(Name)", "Volume ID", "Volume Name"; first=0}; name="("fss[$1]")"; printf formatStr, region, $1, name, $3, $2}' < $tmpout
+      awk -F, -v region=$region 'BEGIN {first=1; maxNameLen=0; while(getline < "'$tmpout2'") {fss[$1]=$2; if(length($2) > maxNameLen) {maxNameLen=length($2)}}; maxNameLen +=2; formatStr="%12s %21s%-"maxNameLen"s %24s %10s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "(Name)", "Volume ID", "State", "Volume Name"; first=0}; name="("fss[$1]")"; printf formatStr, region, $1, name, $3, $4, $2}' < $tmpout
     else
-      awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %23s %23s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "Volume ID", "Volume Name"; first=0}; printf formatStr, region, $1, $3, $2}' < $tmpout
+      awk -F, -v region=$region 'BEGIN {first=1; formatStr="%12s %21s %24s %10s %s\n"}; {if(first) {printf "\n"; printf formatStr, "Region", "FileSystem ID", "Volume ID", "State", "Volume Name"; first=0}; printf formatStr, region, $1, $3, $4, $2}' < $tmpout
     fi
   else
     if [ $allRegions != "true" ]; then


### PR DESCRIPTION
Allowed all the scripts to handle the -h option consistently.
Added some options to the list_fsxn_filesystem script to show additional information.
For the scripts that accept -a for all regions, how the appropriately skip regions that doesn't support FSxN.