### PR TITLE
Split out the definition of the security group to a separate file.

### DIFF
--- a/Terraform/deploy-fsx-ontap/standalone-module/README.md
+++ b/Terraform/deploy-fsx-ontap/standalone-module/README.md
@@ -168,13 +168,13 @@ terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws_secretsmanager_region | The AWS region where the secret is stored. | `string` | `"us-east-2"` | no |
+| aws_secretsmanager_region | The AWS region where the secret is stored. Can be different from the region where the FSxN file system is deployed. | `string` | `"us-east-2"` | no |
 | fsx_capacity_size_gb | The storage capacity (GiB) of the FSxN file system. Valid values between 1024 and 196608. | `number` | `1024` | no |
 | fsx_deploy_type | The filesystem deployment type. Supports MULTI_AZ_1 and SINGLE_AZ_1 | `string` | `"MULTI_AZ_1"` | no |
 | fsx_name | The deployed filesystem name | `string` | `"terraform-fsxn"` | no |
 | fsx_region | The AWS region where the FSxN file system to be deployed. | `string` | `"us-west-2"` | no |
 | fsx_secret_name | The name of the AWS SecretManager secret that holds the ONTAP administrative password for the fsxadmin user that you can use to administer your file system using the ONTAP CLI and REST API. | `string` | `"fsx_secret"` | no |
-| fsx_subnets | A list of IDs for the subnets that the file system will be accessible from. Up to 2 subnets can be provided. | `map(any)` | <pre>{<br>  "primarysub": "subnet-22222222",<br>  "secondarysub": "subnet-22222222"<br>}</pre> | no |
+| fsx_subnets | A list of subnets IDs that the file system will be accessible from. For MULTI_AZ_1 deployment type, provide both subnets. For SINGLE_AZ_1 deployment type, only the primary subnet is used. | `map(any)` | <pre>{<br>  "primarysub": "subnet-22222222",<br>  "secondarysub": "subnet-33333333"<br>}</pre> | no |
 | fsx_tput_in_MBps | The throughput capacity (in MBps) for the file system. Valid values are 128, 256, 512, 1024, 2048, and 4096. | `number` | `128` | no |
 | svm_name | The name of the Storage Virtual Machine | `string` | `"first_svm"` | no |
 | vol_info | Details for the volume creation | `map(any)` | <pre>{<br>  "cooling_period": 31,<br>  "efficiency": true,<br>  "junction_path": "/vol1",<br>  "size_mg": 1024,<br>  "tier_policy_name": "AUTO",<br>  "vol_name": "vol1"<br>}</pre> | no |

--- a/Terraform/deploy-fsx-ontap/standalone-module/main.tf
+++ b/Terraform/deploy-fsx-ontap/standalone-module/main.tf
@@ -18,120 +18,6 @@ provider "aws" {
   region = var.aws_secretsmanager_region
 }
 
-/* 
- * The following resources are a Security Group followed by ingress and egress rules for FSx ONTAP. 
- * The Security Group is not required for deploying FSx ONTAP, but is included here for completeness.
- *
- * - If you wish to skip this resource, comment out the resource blocks of the Security Group and the rules.
- *
- * - If you wish to use the Security Group, choose the relevant source for the ingress rules (can be either cidr block or security group id)
- *   and modify/uncomment the relevant line in the resource block. Make sure you add your specific value as well. 
- *   Note that currently all rules are configured for source cidr: 10.0.0.0/8
- *
- * Note that a source reference for a Security Group is optional, but is considered to be a best practice.
- * Feel free to add, remove, or change the rules as needed. The rules below are just a suggestion for basic functionality.
- */
-resource "aws_security_group" "fsx_sg" {
-  name        = "fsx_sg"
-  description = "Allow FSx ONTAP required ports"
-  vpc_id      = var.vpc_id
-}
-
-resource "aws_vpc_security_group_ingress_rule" "all_icmp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "Allow all ICMP traffic"
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = -1
-  to_port           = -1
-  ip_protocol       = "icmp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "nfs_tcp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "Remote procedure call for NFS"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 111
-  to_port           = 111
-  ip_protocol       = "tcp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "nfs_udp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "Remote procedure call for NFS"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 111
-  to_port           = 111
-  ip_protocol       = "udp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "cifs" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "NetBIOS service session for CIFS"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 139
-  to_port           = 139
-  ip_protocol       = "tcp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "snmp_tcp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "Simple network management protocol for log collection"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 161
-  to_port           = 162
-  ip_protocol       = "tcp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "snmp_udp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "Simple network management protocol for log collection"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 161
-  to_port           = 162
-  ip_protocol       = "udp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "smb_cifs" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "Microsoft SMB/CIFS over TCP with NetBIOS framing"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 445
-  to_port           = 445
-  ip_protocol       = "tcp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "nfs_mount_tcp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "NFS mount"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 635
-  to_port           = 635
-  ip_protocol       = "tcp"
-}
-
-resource "aws_vpc_security_group_ingress_rule" "nfs_mount_udp" {
-  security_group_id = aws_security_group.fsx_sg.id
-  description       = "NFS mount"
-  cidr_ipv4         = "10.0.0.0/8"
-//  referenced_security_group_id = "sg-11111111111111111"
-  from_port         = 635
-  to_port           = 635
-  ip_protocol       = "udp"
-}
-
-resource "aws_vpc_security_group_egress_rule" "allow_all_traffic" {
-  security_group_id = aws_security_group.fsx_sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol       = "-1"
-}
-
 /*
  * The following resources are for deploying a complete FSx ONTAP file system. 
  * The code below deploys the following resources in this order:
@@ -158,6 +44,7 @@ resource "aws_fsx_ontap_file_system" "terraform-fsxn" {
   tags = {
 	  Name = var.fsx_name
   }
+
 // Additional optional parameters that you may want to specify:
   # weekly_maintenance_start_time = "00:00:00"
   # kms_key_id = ""
@@ -166,7 +53,6 @@ resource "aws_fsx_ontap_file_system" "terraform-fsxn" {
   # disk_iops_configuration = ""
   # endpoint_ip_address_range = ""
   # ha_pairs = 1
-  # Storage_type = "SSD"
   # route_table_ids = []
   # throughput_capacity_per_ha_pair = 0
 }

--- a/Terraform/deploy-fsx-ontap/standalone-module/security_groups.tf
+++ b/Terraform/deploy-fsx-ontap/standalone-module/security_groups.tf
@@ -1,0 +1,248 @@
+/* 
+ * The following defines a Security Group for FSx ONTAP that allows the required ports for NFS, CIFS,
+ * Kerberos, and iSCSI as well as SnapMirror.
+ *
+ * While you don't have to use this SG, one will need to be assigned to the FSx ONTAP file system,
+ * otherwise it won't be able to communicate with the clients.
+ *
+ * - If you wish to skip this resource, rename this file to have a different extention other
+ *   than .tf (e.g. security_groups.tf.kep). You will also need to update the 
+ *   security_group_ids  = [aws_security_group.fsx_sg.id] line in the main.tf file to specify
+ *   the security group you want to use.
+ *
+ * - If you wish to use the Security Group, just set the cidf_block OR security_group_id in the
+ *   locals block below. Do not set both or the creation of the SG will fail.
+ *
+ * Note that a source reference to a Security Group is optional, but is considered to be a best practice.
+ *
+ * Feel free to add, remove, or change the rules as needed. The rules below are just a suggestion
+ * for basic functionality.
+ *
+ */
+
+/* Set either the CIDR block OR the Security Group ID for the source of the ingress rules */
+locals {
+  ciddr_block = "10.0.0.0/8"   // Set this to the CIDR block you want to allow traffic from.
+  security_group_id = ""       // Set this to the Security Group ID that is assigned to clients that you want to allow traffic from.
+}
+
+resource "aws_security_group" "fsx_sg" {
+  name        = "fsx_sg"
+  description = "Allow FSx ONTAP required ports"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "all_icmp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Allow all ICMP traffic"
+  cidr_ipv4         = "0.0.0.0/0"   // Allowing all ICMP traffic from all sources
+  from_port         = -1
+  to_port           = -1
+  ip_protocol       = "icmp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_tcp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Remote procedure call for NFS"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 111
+  to_port           = 111
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_udp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Remote procedure call for NFS"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 111
+  to_port           = 111
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "cifs" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NetBIOS service session for CIFS"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 139
+  to_port           = 139
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "snmp_tcp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Simple network management protocol for log collection"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 161
+  to_port           = 162
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "snmp_udp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Simple network management protocol for log collection"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 161
+  to_port           = 162
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "smb_cifs" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Microsoft SMB/CIFS over TCP with NetBIOS framing"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 445
+  to_port           = 445
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_mount_tcp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NFS mount"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 635
+  to_port           = 635
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "kerberos" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Kerberos authentication"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 749
+  to_port           = 749
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_server_daemon" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NFS server daemon"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 2049
+  to_port           = 2049
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_server_daemon_udp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NFS server daemon"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 2049
+  to_port           = 2049
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_lock_daemon" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NFS lock daemon"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 4045
+  to_port           = 4045
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_lock_daemon_udp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NFS lock daemon"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 4045
+  to_port           = 4045
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_status_monitor" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Status monitor for NFS"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 4046
+  to_port           = 4046
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_status_monitor_udp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Status monitor for NFS"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 4046
+  to_port           = 4046
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_rquotad" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Remote quota server for NFS"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 4049
+  to_port           = 4049
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "iscsi_tcp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "iSCSI"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 3260
+  to_port           = 3260
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "Snapmirror_Intercluster_communication" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Snapmirror Intercluster communication"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 11104
+  to_port           = 11104
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "Snapmirror_data_transfer" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "Snapmirror data transfer"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 11105
+  to_port           = 11105
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nfs_mount_udp" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "NFS mount"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 635
+  to_port           = 635
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh" {
+  security_group_id = aws_security_group.fsx_sg.id
+  description       = "ssh"
+  cidr_ipv4         = (local.ciddr_block != "" ? local.ciddr_block : null)
+  referenced_security_group_id = (local.security_group_id != "" ? local.security_group_id : null)
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic" {
+  security_group_id = aws_security_group.fsx_sg.id
+  cidr_ipv4         = "0.0.0.0/0"  // Allow all output traffic.
+  ip_protocol       = "-1"
+}

--- a/Terraform/deploy-fsx-ontap/standalone-module/variables.tf
+++ b/Terraform/deploy-fsx-ontap/standalone-module/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_secretsmanager_region" {
-   description = "The AWS region where the secret is stored."
+   description = "The AWS region where the secret is stored. Can be different from the region where the FSxN file system is deployed."
    type        = string
    default     = "us-east-2"
 }
@@ -43,11 +43,11 @@ variable "fsx_region" {
 }
 
 variable "fsx_subnets" {
-   description = "A list of IDs for the subnets that the file system will be accessible from. Up to 2 subnets can be provided."
+   description = "A list of subnets IDs that the file system will be accessible from. For MULTI_AZ_1 deployment type, provide both subnets. For SINGLE_AZ_1 deployment type, only the primary subnet is used."
    type        = map(any)
    default = {
       "primarysub"   = "subnet-22222222"
-      "secondarysub" = "subnet-22222222"
+      "secondarysub" = "subnet-33333333"
    }
 }
 


### PR DESCRIPTION
Split out the definition of the security group to a separate file. Also, had it use a local variable for the CIDR and source security_group_id so the user would only have to update one place. Also, added more rules to cover more of the protocols.